### PR TITLE
feat(docs): Add authentication steps to Google Workspace

### DIFF
--- a/src/main/resources/doc/io.kestra.plugin.googleworkspace.md
+++ b/src/main/resources/doc/io.kestra.plugin.googleworkspace.md
@@ -1,0 +1,6 @@
+### Authentication
+
+All tasks must be authenticated for the Google Cloud Platform. You can do it in multiple ways:
+
+- By setting the task `serviceAccount` property that must contain the service account JSON content. It can be handy to set this property globally by using [task defaults](../../docs/administrator-guide/configuration/others/#kestra-tasks-defaults) if your cluster access only one GCP project.
+- By setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable on the nodes running Kestra. It must point to an application credentials file. **Warning:** It must be the same on all worker nodes and can cause some security concerns.

--- a/src/main/resources/doc/io.kestra.plugin.googleworkspace.md
+++ b/src/main/resources/doc/io.kestra.plugin.googleworkspace.md
@@ -2,5 +2,5 @@
 
 All tasks must be authenticated for the Google Cloud Platform. You can do it in multiple ways:
 
-- By setting the task `serviceAccount` property that must contain the service account JSON content. It can be handy to set this property globally by using [task defaults](../../docs/administrator-guide/configuration/others/#kestra-tasks-defaults) if your cluster access only one GCP project.
-- By setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable on the nodes running Kestra. It must point to an application credentials file. **Warning:** It must be the same on all worker nodes and can cause some security concerns.
+- By setting the task `serviceAccount` property that must contain the service account JSON content. It can be handy to set this property globally by using [task defaults](../../docs/administrator-guide/configuration/others/#kestra-tasks-defaults).
+- By setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable on the server running Kestra. It must point to an application credentials file. **Warning:** It must be the same on all worker nodes and can cause some security concerns.


### PR DESCRIPTION
This part of the authentication applies to Google Workspace tasks, and hence adding it.