### PR TITLE
Upload task return incorrect size

### DIFF
--- a/src/main/java/io/kestra/plugin/googleworkspace/drive/Export.java
+++ b/src/main/java/io/kestra/plugin/googleworkspace/drive/Export.java
@@ -73,6 +73,10 @@ public class Export extends AbstractDrive implements RunnableTask<Export.Output>
 
             runContext.metric(Counter.of("size", file.size()));
 
+            // For Google apps files such as doc, spreadsheet - file.getSize() will return: null, 1 or 1024 (Which is incorrect value)
+            // Hardcoding file size from tempFile size in bytes that have been exported/created
+            file.setSize(tempFile.length());
+
             logger.debug("Download from '{}'", fileId);
 
             return Output

--- a/src/main/java/io/kestra/plugin/googleworkspace/drive/Export.java
+++ b/src/main/java/io/kestra/plugin/googleworkspace/drive/Export.java
@@ -73,7 +73,7 @@ public class Export extends AbstractDrive implements RunnableTask<Export.Output>
 
             runContext.metric(Counter.of("size", file.size()));
 
-            // For Google apps files such as doc, spreadsheet - file.getSize() will return: null, 1 or 1024 (Which is incorrect value)
+            // For Google apps files such as doc, spreadsheet, csv - file.getSize() will return: null, 1 or 1024 (Which is incorrect value)
             // Hardcoding file size from tempFile size in bytes that have been exported/created
             file.setSize(tempFile.length());
 

--- a/src/main/java/io/kestra/plugin/googleworkspace/drive/Upload.java
+++ b/src/main/java/io/kestra/plugin/googleworkspace/drive/Upload.java
@@ -85,20 +85,24 @@ public class Upload extends AbstractCreate implements RunnableTask<Upload.Output
             file = service
                 .files()
                 .update(runContext.render(this.fileId), fileMetadata, fileContent)
-                .setFields("id, name, size, version, createdTime, parents, trashed")
+                .setFields("id, name, version, createdTime, parents, trashed, mimeType")
                 .setSupportsTeamDrives(true)
                 .execute();
         } else {
             file = service
                 .files()
                 .create(fileMetadata, fileContent)
-                .setFields("id, name, size, version, createdTime, parents, trashed")
+                .setFields("id, name, version, createdTime, parents, trashed, mimeType")
                 .setSupportsTeamDrives(true)
                 .execute();
         }
 
         runContext.metric(Counter.of("size", file.size()));
         logger.debug("Upload from '{}' to '{}'", from, fileMetadata.getParents());
+
+        // For Google apps files such as doc, spreadsheet - file.getSize() will return: null, 1 or 1024 (Which is incorrect value)
+        // Hardcoding file size from tempFile size in bytes that have been exported/created
+        file.setSize(tempFile.length());
 
         return Output
             .builder()

--- a/src/main/java/io/kestra/plugin/googleworkspace/drive/Upload.java
+++ b/src/main/java/io/kestra/plugin/googleworkspace/drive/Upload.java
@@ -100,7 +100,7 @@ public class Upload extends AbstractCreate implements RunnableTask<Upload.Output
         runContext.metric(Counter.of("size", file.size()));
         logger.debug("Upload from '{}' to '{}'", from, fileMetadata.getParents());
 
-        // For Google apps files such as doc, spreadsheet - file.getSize() will return: null, 1 or 1024 (Which is incorrect value)
+        // For Google apps files such as doc, spreadsheet, csv - file.getSize() will return: null, 1 or 1024 (Which is incorrect value)
         // Hardcoding file size from tempFile size in bytes that have been exported/created
         file.setSize(tempFile.length());
 

--- a/src/test/java/io/kestra/plugin/googleworkspace/drive/SuiteTest.java
+++ b/src/test/java/io/kestra/plugin/googleworkspace/drive/SuiteTest.java
@@ -75,7 +75,7 @@ class SuiteTest {
 
         Upload.Output uploadRun = upload.run(TestsUtils.mockRunContext(runContextFactory, upload, Map.of()));
 
-        assertThat(uploadRun.getFile().getSize(), greaterThan(0L));
+        assertThat(uploadRun.getFile().getSize(), is(328L));
 
         Export export = Export.builder()
             .id(SuiteTest.class.getSimpleName())
@@ -88,9 +88,10 @@ class SuiteTest {
         Export.Output exportRun = export.run(TestsUtils.mockRunContext(runContextFactory, export, Map.of()));
 
         assertThat(exportRun.getFile().getName(), is(uploadRun.getFile().getName()));
-        assertThat(exportRun.getFile().getSize(), greaterThan(0L));
-        assertThat(exportRun.getFile().getVersion(), notNullValue());
-        assertThat(exportRun.getFile().getMimeType(), notNullValue());
+        assertThat(exportRun.getFile().getSize(), notNullValue());
+        assertThat(exportRun.getFile().getSize(), greaterThanOrEqualTo(318L));
+        assertThat(exportRun.getFile().getVersion(), greaterThanOrEqualTo(uploadRun.getFile().getVersion()));
+        assertThat(exportRun.getFile().getMimeType(), is(uploadRun.getFile().getMimeType()));
         assertThat(exportRun.getFile().getCreatedTime(), is(uploadRun.getFile().getCreatedTime()));
         assertThat(exportRun.getFile().getParents().equals(uploadRun.getFile().getParents()), is(true));
         assertThat(exportRun.getFile().getTrashed(), is(uploadRun.getFile().getTrashed()));
@@ -114,7 +115,7 @@ class SuiteTest {
 
         Upload.Output upload2Run = upload2.run(TestsUtils.mockRunContext(runContextFactory, upload, Map.of()));
 
-        assertThat(upload2Run.getFile().getSize(), is(1024L));
+        assertThat(upload2Run.getFile().getSize(), is(328L));
 
         Export export2 = Export.builder()
             .id(SuiteTest.class.getSimpleName())
@@ -127,9 +128,10 @@ class SuiteTest {
         Export.Output exportRun2 = export2.run(TestsUtils.mockRunContext(runContextFactory, export, Map.of()));
 
         assertThat(exportRun2.getFile().getName(), is(upload2Run.getFile().getName()));
-        assertThat(exportRun2.getFile().getSize(), is(upload2Run.getFile().getSize()));
-        assertThat(exportRun2.getFile().getVersion(), is(upload2Run.getFile().getVersion()));
-        assertThat(exportRun2.getFile().getMimeType(), notNullValue());
+        assertThat(exportRun.getFile().getSize(), notNullValue());
+        assertThat(exportRun.getFile().getSize(), greaterThanOrEqualTo(318L));
+        assertThat(exportRun2.getFile().getVersion(), greaterThanOrEqualTo(upload2Run.getFile().getVersion()));
+        assertThat(exportRun2.getFile().getMimeType(), is(upload2Run.getFile().getMimeType()));
         assertThat(exportRun2.getFile().getCreatedTime(), is(upload2Run.getFile().getCreatedTime()));
         assertThat(exportRun2.getFile().getParents().equals(upload2Run.getFile().getParents()), is(true));
         assertThat(exportRun2.getFile().getTrashed(), is(upload2Run.getFile().getTrashed()));


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->
- Was changed code that setting size of files #110, because for Google Drive files such as doc, spreadsheet, csv, etc - file.getSize() will return null, as they don't consumer any space in drive
- Versioning issue, as far, as i know, seems like occurs only for text/csv contentType on Google Drive side
- Changed tests
---

### How the changes have been QAed?

```yaml
tasks:
  - id: "upload"
    type: "io.kestra.plugin.googleworkspace.drive.Upload"
    from: "{{ inputs.file }}"
    parents:
     - "parent-uuid-123x7kd"
    name: "order.csv"
    contentType: "text/csv"
    mimeType: "application/vnd.google-apps.spreadsheet"
    serviceAccount: "{{ secret('GCP_SERVICE_ACCOUNT_JSON') }}"
```

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->
