### PR TITLE
fix(plugin-googleworkspace): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/googleworkspace/chat/package-info.java
+++ b/src/main/java/io/kestra/plugin/googleworkspace/chat/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Google Chat",
     description = "This sub-group of plugins contains tasks for Google Chat notifications.",
     categories = PluginSubGroup.PluginCategory.BUSINESS
 )


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while metadata uses a different slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge