### PR TITLE
refactor: update deprecated task identifiers in examples

### DIFF
--- a/src/main/java/io/kestra/plugin/googleworkspace/calendar/EventCreatedTrigger.java
+++ b/src/main/java/io/kestra/plugin/googleworkspace/calendar/EventCreatedTrigger.java
@@ -85,7 +85,7 @@ import io.kestra.core.models.annotations.PluginProperty;
                     values: "{{ trigger.events }}"
                     tasks:
                       - id: send_notification
-                        type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+                        type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
                         url: "{{ secret('SLACK_WEBHOOK') }}"
                         payload: |
                           {

--- a/src/main/java/io/kestra/plugin/googleworkspace/drive/FileCreatedTrigger.java
+++ b/src/main/java/io/kestra/plugin/googleworkspace/drive/FileCreatedTrigger.java
@@ -96,7 +96,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 
                 tasks:
                   - id: notify
-                    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+                    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
                     url: "{{ secret('SLACK_WEBHOOK') }}"
                     payload: |
                       {

--- a/src/main/java/io/kestra/plugin/googleworkspace/mail/MailReceivedTrigger.java
+++ b/src/main/java/io/kestra/plugin/googleworkspace/mail/MailReceivedTrigger.java
@@ -79,7 +79,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 
                 tasks:
                   - id: notify_urgent
-                    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+                    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
                     url: "{{ secret('SLACK_WEBHOOK') }}"
                     payload: |
                       {

--- a/src/main/java/io/kestra/plugin/googleworkspace/sheets/SheetModifiedTrigger.java
+++ b/src/main/java/io/kestra/plugin/googleworkspace/sheets/SheetModifiedTrigger.java
@@ -107,7 +107,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 
                 tasks:
                   - id: notify
-                    type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+                    type: io.kestra.plugin.slack.notifications.SlackIncomingWebhook
                     url: "{{ secret('SLACK_WEBHOOK') }}"
                     payload: |
                       {

--- a/src/test/resources/flows/common/main-flow-that-fails.yaml
+++ b/src/test/resources/flows/common/main-flow-that-fails.yaml
@@ -2,4 +2,4 @@ id: main-flow-that-fails
 namespace: io.kestra.tests
 tasks:
   - id: failed
-    type: io.kestra.core.tasks.executions.Fail
+    type: io.kestra.plugin.core.execution.Fail


### PR DESCRIPTION
Updates the deprecated task identifiers in the examples to their current names