### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/googleworkspace/GcpInterface.java
+++ b/src/main/java/io/kestra/plugin/googleworkspace/GcpInterface.java
@@ -11,7 +11,7 @@ public interface GcpInterface {
     @Schema(
         title = "The GCP service account key"
     )
-    @PluginProperty(group = "execution")
+    @PluginProperty(group = "execution", secret = true)
     Property<String> getServiceAccount();
 
     @Schema(


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — GCP serviceAccount key field missing `@PluginProperty(secret=true)` — `src/main/java/io/kestra/plugin/googleworkspace/GcpInterface.java:14` — Added `secret = true` to the `@PluginProperty` annotation on `getServiceAccount()` so the GCP service account JSON key is masked in the UI, logs, and API responses.
- **HIGH** — OAuth clientSecret field missing `@PluginProperty(secret=true)` in AbstractMail — `src/main/java/io/kestra/plugin/googleworkspace/mail/AbstractMail.java:53` — Already remediated on the current default branch (`secret = true` present); verified, no change needed.
- **HIGH** — OAuth refreshToken field missing `@PluginProperty(secret=true)` in AbstractMail — `src/main/java/io/kestra/plugin/googleworkspace/mail/AbstractMail.java:61` — Already remediated on the current default branch (`secret = true` present); verified, no change needed.
- **HIGH** — OAuth accessToken field missing `@PluginProperty(secret=true)` in AbstractMail — `src/main/java/io/kestra/plugin/googleworkspace/mail/AbstractMail.java:68` — Already remediated on the current default branch (`secret = true` present); verified, no change needed.
- **HIGH** — OAuth clientSecret, refreshToken, and accessToken fields missing `@PluginProperty(secret=true)` in MailReceivedTrigger — `src/main/java/io/kestra/plugin/googleworkspace/mail/MailReceivedTrigger.java:120` — Already remediated on the current default branch (`secret = true` present on all three fields); verified, no change needed.

No MEDIUM or LOW findings were reported in the audit EPIC.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-googleworkspace/issues/402
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
